### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xDelphi
+# Exercism Delphi Pascal Track
 
-[![Build Status](https://travis-ci.org/exercism/xdelphi.svg?branch=master)](https://travis-ci.org/exercism/xdelphi)
+[![Build Status](https://travis-ci.org/exercism/delphi.svg?branch=master)](https://travis-ci.org/exercism/delphi)
 
 Exercism exercises in Delphi Pascal.
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "delphi",
   "language": "Delphi Pascal",
-  "repository": "https://github.com/exercism/xdelphi",
+  "repository": "https://github.com/exercism/delphi",
   "active": true,
   "exercises": [
     {


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1