### PR TITLE
bank-account: guard against exceptions

### DIFF
--- a/exercises/bank-account/uBankAccountTests.pas
+++ b/exercises/bank-account/uBankAccountTests.pas
@@ -118,15 +118,17 @@ begin
       procedure
       var j: integer;
       begin
-        for j := 1 to iterations do
-        begin
-          account.UpdateBalance(1);
-          account.UpdateBalance(-1);
+        try
+          for j := 1 to iterations do
+          begin
+            account.UpdateBalance(1);
+            account.UpdateBalance(-1);
+          end;
+        finally
+          dec(activeThreadCount);
+          if activeThreadCount <= 0 then
+            allthreadsDone.SetEvent;
         end;
-
-        dec(activeThreadCount);
-        if activeThreadCount <= 0 then
-          allthreadsDone.SetEvent;
       end)
       .Start;
   end;

--- a/exercises/bank-account/uBankAccountTests.pas
+++ b/exercises/bank-account/uBankAccountTests.pas
@@ -31,7 +31,7 @@ type
   end;
 
 implementation
-uses System.Classes, System.SyncObjs, uBankAccount;
+uses System.SysUtils, System.Classes, System.SyncObjs, uBankAccount;
 
 const HalfCentTolerance = 0.005;
 
@@ -133,7 +133,7 @@ begin
       .Start;
   end;
 
-  assert.AreEqual(wrSignaled,allthreadsDone.WaitFor(60000));
+  assert.AreEqual(wrSignaled,allthreadsDone.WaitFor(60000), format('%d threads still active',[activeThreadCount]));
   assert.AreEqual(0, account.Balance, HalfCentTolerance);
 end;
 


### PR DESCRIPTION
If an exception is raised with in the execution of a thread we need that thread to decrement the active thread count and have the allthreadsDone event to be set regardless of how a thread terminates.  UpdateBalance will raise an exception if the bank account is not open.