### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,14 +5,20 @@
   "active": true,
   "exercises": [
     {
+      "uuid": "e3b0af0d-7ecd-43c8-a394-91ef2cf4d7d0",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Text formatting"
       ]
     },
     {
+      "uuid": "0c75f779-dbf1-43f7-8f36-2e8d34fec410",
       "slug": "two-fer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Text formatting",
@@ -20,7 +26,10 @@
       ]
     },
     {
+      "uuid": "b3f7e56b-8a69-4b7f-bbb8-5fbcfa357eba",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings",
@@ -28,14 +37,20 @@
       ]
     },
     {
+      "uuid": "761e0143-163c-48ed-8bb3-5ad6a59fb69d",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Integers"
       ]
     },
     {
+      "uuid": "72022a7f-ff34-4a9b-b710-546eebd094e1",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings",
@@ -43,7 +58,10 @@
       ]
     },
     {
+      "uuid": "cf22573e-9099-4df5-86d6-02e9bf42784d",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Text formatting",
@@ -51,7 +69,10 @@
       ]
     },
     {
+      "uuid": "6bc985bc-f04f-41de-9582-e0d51ea8df54",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Strings",
@@ -59,14 +80,20 @@
       ]
     },
     {
+      "uuid": "746fdc7b-8d7f-4df1-8d68-7af5d5c63396",
       "slug": "bank-account",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Classes"
       ]
     },
     {
+      "uuid": "a77d309f-ddd6-4700-b300-347fb7e1d916",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Dictionaries",
@@ -74,7 +101,10 @@
       ]
     },
     {
+      "uuid": "3cc7a1b6-b613-4cf1-9318-fd2e48eac6a4",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Dictionaries",
@@ -83,7 +113,10 @@
       ]
     },
     {
+      "uuid": "dbf6dfed-b3c1-4bac-8d86-4584c1d9f08c",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Integers",
@@ -91,7 +124,10 @@
       ]
     },
     {
+      "uuid": "b30fbfa4-8568-467c-bf50-9d9fd49d3af2",
       "slug": "collatz-conjecture",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Algorithms",
@@ -100,7 +136,10 @@
       ]
     },
     {
+      "uuid": "76754970-3b28-45f6-8f36-10f063b3f846",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Text formatting",
@@ -108,7 +147,10 @@
       ]
     },
     {
+      "uuid": "4d8b5c36-3562-41a6-aaca-b5229059a009",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Parsing",
@@ -116,14 +158,20 @@
       ]
     },
     {
+      "uuid": "95ca4105-b3f7-42f8-a07d-8d912056ed26",
       "slug": "perfect-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Integers"
       ]
     },
     {
+      "uuid": "c89324f8-8f40-4e99-9ce2-4bf11d4d91d5",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Searching",
@@ -132,7 +180,10 @@
       ]
     },
     {
+      "uuid": "6488fc37-7bd4-4854-8043-8b261554695d",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Time",
@@ -140,7 +191,10 @@
       ]
     },
     {
+      "uuid": "6404ad71-4f20-4f5b-8530-8ba1578e9550",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Integers",
@@ -148,7 +202,10 @@
       ]
     },
     {
+      "uuid": "fcaf9a85-579b-4607-8d2c-b6353664502d",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Bitwise operations",
@@ -156,7 +213,10 @@
       ]
     },
     {
+      "uuid": "4fd252a7-520a-416d-b976-a8f4cf3c4516",
       "slug": "saddle-points",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Matrices",
@@ -165,7 +225,10 @@
       ]
     },
     {
+      "uuid": "51b2fe3e-996c-41f2-86cd-c6666898c850",
       "slug": "circular-buffer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Queues",
@@ -173,7 +236,10 @@
       ]
     },
     {
+      "uuid": "0648988c-0916-4651-897a-349c94c32ca8",
       "slug": "minesweeper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Parsing",
@@ -181,7 +247,10 @@
       ]
     },
     {
+      "uuid": "b4d9cd9c-bdc7-4485-bcce-80e4303fad51",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Control-flow (loops)",
@@ -189,7 +258,10 @@
       ]
     },
     {
+      "uuid": "f823e453-90c1-4f9f-ab73-d560ca3675f0",
       "slug": "bowling",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Algorithms",
@@ -197,11 +269,18 @@
       ]
     },
     {
+      "uuid": "d83a653b-da78-4f49-9ab2-3cc947825a2b",
       "slug": "book-store",
-      "difficulty": 6
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
+      "topics": null
     },
     {
+      "uuid": "f522e311-2d29-4fe2-a91c-5357ff85fde6",
       "slug": "wordy",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Parsing",
@@ -210,7 +289,10 @@
       ]
     },
     {
+      "uuid": "250c222d-3d29-42fd-8695-bc9fc33db6f5",
       "slug": "poker",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Parsing",


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16