### PR TITLE
circular-buffer: update to match v1.0.1

### DIFF
--- a/exercises/circular-buffer/uCircularBufferExample.pas
+++ b/exercises/circular-buffer/uCircularBufferExample.pas
@@ -8,7 +8,7 @@ type
   ['{E3531870-DA5D-451A-9E7A-86B1C46B4D29}']
     function Read: T;
     procedure Write(aValue: T);
-    procedure ForceWrite(aValue: T);
+    procedure OverWrite(aValue: T);
     procedure Clear;
   end;
 
@@ -21,7 +21,7 @@ type
     destructor destroy;
     function Read: T;
     procedure Write(aValue: T);
-    procedure ForceWrite(aValue: T);
+    procedure OverWrite(aValue: T);
     procedure Clear;
   end;
 
@@ -57,7 +57,7 @@ begin
   FBuffer.Enqueue(aValue);
 end;
 
-procedure TCircularBuffer<T>.ForceWrite(aValue: T);
+procedure TCircularBuffer<T>.OverWrite(aValue: T);
 begin
   if FBuffer.Count = FSize then
     FBuffer.Dequeue;

--- a/exercises/circular-buffer/uCircularBufferTests.pas
+++ b/exercises/circular-buffer/uCircularBufferTests.pas
@@ -4,6 +4,9 @@ interface
 uses
   DUnitX.TestFramework;
 
+const
+   CanonicalVersion = '1.0.1';
+
 type
 
   [TestFixture]
@@ -11,7 +14,11 @@ type
   public
     [Test]
 //  [Ignore('Comment the "[Ignore]" statement to run the test')]
-    procedure Write_and_read_back_one_item;
+    procedure reading_empty_buffer_should_fail;
+
+    [Test]
+    [Ignore]
+    procedure can_read_an_item_just_written;
 
     [Test]
     [Ignore]
@@ -19,37 +26,53 @@ type
 
     [Test]
     [Ignore]
-    procedure Clearing_buffer;
+    procedure each_item_may_only_be_read_once;
 
     [Test]
     [Ignore]
-    procedure Alternate_write_and_read;
+    procedure items_are_read_in_the_order_they_are_written;
 
     [Test]
     [Ignore]
-    procedure Reads_back_oldest_item;
+    procedure full_buffer_cannot_be_written_to;
 
     [Test]
     [Ignore]
-    procedure Writing_to_a_full_buffer_throws_an_exception;
+    procedure a_read_frees_up_capacity_for_another_write;
 
     [Test]
     [Ignore]
-    procedure Overwriting_oldest_item_in_a_full_buffer;
+    procedure read_position_is_maintained_even_across_multiple_writes;
 
     [Test]
     [Ignore]
-    procedure Forced_writes_to_non_full_buffer_should_behave_like_writes;
+    procedure items_cleared_out_of_buffer_cannot_be_read;
 
     [Test]
     [Ignore]
-    procedure Alternate_read_and_write_into_buffer_overflow;
+    procedure clear_frees_up_capacity_for_another_write;
+
+    [Test]
+    [Ignore]
+    procedure clear_does_nothing_on_empty_buffer;
+
+    [Test]
+    [Ignore]
+    procedure overwrite_acts_like_write_on_non_full_buffer;
+
+    [Test]
+    [Ignore]
+    procedure overwrite_replaces_the_oldest_item_on_full_buffer;
+
+    [Test]
+    [Ignore]
+    procedure overwrite_replaces_the_oldest_item_remaining_in_buffer_following_a_read;
   end;
 
 implementation
 uses System.SysUtils, uCircularBuffer;
 
-procedure TestCircularBuffer.Write_and_read_back_one_item;
+procedure TestCircularBuffer.can_read_an_item_just_written;
 var MyBuffer: ICircularBuffer<char>;
     Actual: char;
 begin
@@ -57,6 +80,45 @@ begin
   MyBuffer.Write('1');
   Actual := MyBuffer.Read;
   assert.AreEqual('1', Actual);
+end;
+
+procedure TestCircularBuffer.clear_does_nothing_on_empty_buffer;
+var MyBuffer: ICircularBuffer<integer>;
+    Actual: integer;
+    MyProc: TTestLocalMethod;
+begin
+  MyBuffer := TCircularBuffer<integer>.Create(1);
+  MyBuffer.Clear;
+
+  MyProc := procedure
+            begin
+              MyBuffer.Write(1);
+            end;
+
+  Assert.WillNotRaise(MyProc, EInvalidOpException);
+
+  Actual := MyBuffer.Read;
+  Assert.AreEqual(1, Actual);
+end;
+
+procedure TestCircularBuffer.clear_frees_up_capacity_for_another_write;
+var MyBuffer: ICircularBuffer<integer>;
+    Actual: integer;
+    MyProc: TTestLocalMethod;
+begin
+  MyBuffer := TCircularBuffer<integer>.Create(1);
+  MyBuffer.Write(1);
+  MyBuffer.Clear;
+
+  MyProc := procedure
+            begin
+              MyBuffer.Write(2);
+            end;
+
+  Assert.WillNotRaise(MyProc, EInvalidOpException);
+
+  Actual := MyBuffer.Read;
+  Assert.AreEqual(2, Actual);
 end;
 
 procedure TestCircularBuffer.Write_and_read_back_multiple_items;
@@ -82,16 +144,14 @@ begin
   Assert.WillRaise(MyProc, EInvalidOpException);
 end;
 
-procedure TestCircularBuffer.Clearing_buffer;
+procedure TestCircularBuffer.items_cleared_out_of_buffer_cannot_be_read;
 var MyBuffer: ICircularBuffer<char>;
     Act1, Act2: char;
     MyProc: TTestLocalMethod;
 begin
-  MyBuffer := TCircularBuffer<char>.Create(3);
+  MyBuffer := TCircularBuffer<char>.Create(1);
 
   MyBuffer.Write('1');
-  MyBuffer.Write('2');
-  MyBuffer.Write('3');
 
   MyBuffer.Clear;
 
@@ -100,79 +160,120 @@ begin
               MyBuffer.Read;
             end;
   Assert.WillRaise(MyProc, EInvalidOpException);
-
-  MyBuffer.Write('1');
-  MyBuffer.Write('2');
-
-  Act1 := MyBuffer.Read;
-  MyBuffer.Write('3');
-  Act2 := MyBuffer.Read;
-
-  Assert.AreEqual('1', Act1);
-  Assert.AreEqual('2', Act2);
 end;
 
-procedure TestCircularBuffer.Alternate_write_and_read;
-var MyBuffer: ICircularBuffer<char>;
-    Act1, Act2: char;
+procedure TestCircularBuffer.each_item_may_only_be_read_once;
+var MyBuffer: ICircularBuffer<integer>;
+    Actual: integer;
+    MyProc: TTestLocalMethod;
 begin
-  MyBuffer := TCircularBuffer<char>.create(2);
-  MyBuffer.Write('1');
-  Act1 := MyBuffer.Read;
-  MyBuffer.Write('2');
-  Act2 := MyBuffer.Read;
-
-  Assert.AreEqual('1', Act1);
-  Assert.AreEqual('2', Act2);
+  MyBuffer := TCircularBuffer<integer>.Create(1);
+  MyBuffer.Write(1);
+  Actual := MyBuffer.Read;
+  assert.AreEqual(1, Actual);
+  MyProc := procedure
+            begin
+              MyBuffer.Read;
+            end;
+  Assert.WillRaise(MyProc, EInvalidOpException);
 end;
 
-procedure TestCircularBuffer.Reads_back_oldest_item;
+procedure TestCircularBuffer.a_read_frees_up_capacity_for_another_write;
+var MyBuffer: ICircularBuffer<integer>;
+    Actual: integer;
+    MyProc: TTestLocalMethod;
+begin
+  MyBuffer := TCircularBuffer<integer>.create(1);
+  MyBuffer.Write(1);
+  Actual := MyBuffer.Read;
+
+  MyProc := procedure
+            begin
+              MyBuffer.Write(2);
+            end;
+  Assert.WillNotRaise(MyProc, EInvalidOpException);
+  Actual := MyBuffer.Read;
+  Assert.AreEqual(2, Actual);
+end;
+
+procedure TestCircularBuffer.read_position_is_maintained_even_across_multiple_writes;
 var MyBuffer: ICircularBuffer<char>;
-    Act1, Act2, Act3: char;
+    Actual: char;
 begin
   MyBuffer := TCircularBuffer<char>.create(3);
   MyBuffer.Write('1');
   MyBuffer.Write('2');
-  Act1 := MyBuffer.Read;
+  Actual := MyBuffer.Read;
+  Assert.AreEqual('1', Actual);
 
   MyBuffer.Write('3');
-  Act2 := MyBuffer.Read;
-  Act3 := MyBuffer.Read;
 
-  Assert.AreEqual('2', Act2);
-  Assert.AreEqual('3', Act3);
+  Actual := MyBuffer.Read;
+  Assert.AreEqual('2',Actual);
+  Actual := MyBuffer.Read;
+  Assert.AreEqual('3',Actual);
 end;
 
-procedure TestCircularBuffer.Writing_to_a_full_buffer_throws_an_exception;
+procedure TestCircularBuffer.full_buffer_cannot_be_written_to;
 var MyBuffer: ICircularBuffer<char>;
     MyProc: TTestLocalMethod;
 begin
-  MyBuffer := TCircularBuffer<char>.create(2);
+  MyBuffer := TCircularBuffer<char>.create(1);
   MyBuffer.Write('1');
-  MyBuffer.Write('2');
 
   MyProc := procedure
             begin
-              MyBuffer.Write('A');
+              MyBuffer.Write('2');
             end;
   Assert.WillRaise(MyProc, EInvalidOpException);
 end;
 
-procedure TestCircularBuffer.Overwriting_oldest_item_in_a_full_buffer;
-var MyBuffer: ICircularBuffer<char>;
-    Act1, Act2: char;
+procedure TestCircularBuffer.overwrite_replaces_the_oldest_item_on_full_buffer;
+var MyBuffer: ICircularBuffer<integer>;
+    Act1, Act2: integer;
     MyProc: TTestLocalMethod;
 begin
-  MyBuffer := TCircularBuffer<char>.create(2);
-  MyBuffer.Write('1');
-  MyBuffer.Write('2');
-  MyBuffer.ForceWrite('A');
+  MyBuffer := TCircularBuffer<integer>.create(2);
+  MyBuffer.Write(1);
+  MyBuffer.Write(2);
+  MyBuffer.OverWrite(3);
 
   Act1 := MyBuffer.Read;
   Act2 := MyBuffer.Read;
 
-  Assert.AreEqual('2', Act1);
-  Assert.AreEqual('A', Act2);
+  Assert.AreEqual(2, Act1);
+  Assert.AreEqual(3, Act2);
+end;
+
+procedure TestCircularBuffer.overwrite_replaces_the_oldest_item_remaining_in_buffer_following_a_read;
+var MyBuffer: ICircularBuffer<integer>;
+    MyProc: TTestLocalMethod;
+    Actual: integer;
+begin
+  MyBuffer := TCircularBuffer<integer>.create(3);
+  MyBuffer.Write(1);
+  MyBuffer.Write(2);
+  MyBuffer.Write(3);
+
+  Actual := MyBuffer.Read;
+  Assert.AreEqual(1,Actual);
+
+  MyBuffer.Write(4);
+  MyBuffer.OverWrite(5);
+
+  Actual := MyBuffer.Read;
+  Assert.AreEqual(3,Actual);
+  Actual := MyBuffer.Read;
+  Assert.AreEqual(4,Actual);
+  Actual := MyBuffer.Read;
+  Assert.AreEqual(5,Actual);
+end;
+
+procedure TestCircularBuffer.reading_empty_buffer_should_fail;
+var MyBuffer: ICircularBuffer<integer>;
+    MyProc: TTestLocalMethod;
+begin
+  MyBuffer := TCircularBuffer<integer>.create(2);
   MyProc := procedure
             begin
               MyBuffer.Read;
@@ -180,14 +281,14 @@ begin
   Assert.WillRaise(MyProc, EInvalidOpException);
 end;
 
-procedure TestCircularBuffer.Forced_writes_to_non_full_buffer_should_behave_like_writes;
+procedure TestCircularBuffer.overwrite_acts_like_write_on_non_full_buffer;
 var MyBuffer: ICircularBuffer<char>;
     Act1, Act2: char;
     MyProc: TTestLocalMethod;
 begin
   MyBuffer := TCircularBuffer<char>.create(2);
   MyBuffer.Write('1');
-  MyBuffer.ForceWrite('2');
+  MyBuffer.OverWrite('2');
 
   Act1 := MyBuffer.Read;
   Act2 := MyBuffer.Read;
@@ -201,47 +302,20 @@ begin
   Assert.WillRaise(MyProc, EInvalidOpException);
 end;
 
-procedure TestCircularBuffer.Alternate_read_and_write_into_buffer_overflow;
+procedure TestCircularBuffer.items_are_read_in_the_order_they_are_written;
 var MyBuffer: ICircularBuffer<char>;
     Act: TArray<char>;
-    MyProc: TTestLocalMethod;
 begin
-  SetLength(Act, 8);
-  MyBuffer := TCircularBuffer<char>.create(5);
+  SetLength(Act, 2);
+  MyBuffer := TCircularBuffer<char>.create(2);
   MyBuffer.Write('1');
   MyBuffer.Write('2');
-  MyBuffer.Write('3');
 
   Act[0] := MyBuffer.Read;
   Act[1] := MyBuffer.Read;
-  MyBuffer.Write('4');
-  Act[2] := MyBuffer.Read;
 
-  MyBuffer.Write('5');
-  MyBuffer.Write('6');
-  MyBuffer.Write('7');
-  MyBuffer.Write('8');
-
-  MyBuffer.ForceWrite('A');
-  MyBuffer.ForceWrite('B');
-
-  Act[3] := MyBuffer.Read;
-  Act[4] := MyBuffer.Read;
-  Act[5] := MyBuffer.Read;
-  Act[6] := MyBuffer.Read;
-  Act[7] := MyBuffer.Read;
-
-  Assert.AreEqual('6', Act[3]);
-  Assert.AreEqual('7', Act[4]);
-  Assert.AreEqual('8', Act[5]);
-  Assert.AreEqual('A', Act[6]);
-  Assert.AreEqual('B', Act[7]);
-
-  MyProc := procedure
-            begin
-              MyBuffer.Read;
-            end;
-  Assert.WillRaise(MyProc, EInvalidOpException);
+  Assert.AreEqual('1', Act[0]);
+  Assert.AreEqual('2', Act[1]);
 end;
 
 initialization


### PR DESCRIPTION
Canonical data was updated back in september '17.