### PR TITLE
phone-number: rename ToString to Formatted

### DIFF
--- a/exercises/phone-number/uPhoneNumberTests.pas
+++ b/exercises/phone-number/uPhoneNumberTests.pas
@@ -206,7 +206,7 @@ procedure PhoneNumberTests.Formats_a_number;
 var phone: IPhoneNumber;
 begin
   phone := NewPhoneNumber('2234567890');
-  assert.AreEqual('(223) 456-7890', phone.ToString);
+  assert.AreEqual('(223) 456-7890', phone.Formatted);
 end;
 
 initialization


### PR DESCRIPTION
ToString is a method of ancestor class TObject.  Each student can override the method with there own, but overridding ancestor methods isn't really in the scope of this exercise, and this particular case is a bonus.