### PR TITLE
track config: bob is now a core exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,7 +33,7 @@
       "uuid": "8bdf3796-592c-48f1-b2ef-8e4deb40cc37"
     },
     {
-      "core": false,
+      "core": true,
       "difficulty": 1,
       "slug": "bob",
       "topics": [


### PR DESCRIPTION
fixes #219
#219 indicates that `isbn-verifier` is being unlocked by a non-core exercise, `bob`.  This PR re-designates `bob` to be a core exercise, which will correct the conflict.