### PR TITLE
reformat About to be V2 compliant

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,6 +1,8 @@
-**Delphi** is an Object Pascal based programming language for desktop, mobile, web, and console software development. Delphi was the [code name](https://edn.embarcadero.com/article/20396) for a yet unnamed product during its initial development prior to its debut in 1995.
+**Delphi** is an Object Pascal based programming language for desktop, mobile, web, and console software development.
+Delphi was the [code name](https://edn.embarcadero.com/article/20396) for a yet unnamed product during its initial development prior to its debut in 1995.
 
-Delphi was originally developed by [Borland](https://en.wikipedia.org/wiki/Borland), lead by Anders Heilsberg as a [RAD](https://en.wikipedia.org/wiki/Rapid_application_development) tool for Windows as the successor of [Turbo Pascal](https://en.wikipedia.org/wiki/Turbo_Pascal). Delphi added full object-orientation to the existing language, and since then the language has grown and supports many other modern language features, including:
+Delphi was originally developed by [Borland](https://en.wikipedia.org/wiki/Borland), lead by Anders Heilsberg as a [RAD](https://en.wikipedia.org/wiki/Rapid_application_development) tool for Windows as the successor of [Turbo Pascal](https://en.wikipedia.org/wiki/Turbo_Pascal).
+Delphi added full object-orientation to the existing language, and since then the language has grown and supports many other modern language features, including:
   
 - **Generics**  
 - **Anonymous Methods (Closures)**  
@@ -10,9 +12,9 @@ Delphi was originally developed by [Borland](https://en.wikipedia.org/wiki/Borla
 - **Native COM support**  
 - **RTTI**  
 
-Like its predecessor Turbo Pascal, at the core of Delphi is a native code compiler.  Turbo Pascal provided an ideal balance between the speed of
-programming and the speed of the resulting programs, clarity of syntax and power
-of expression, these tenets remain true today in Delphi.  More recent versions of Delphi are able to compile native code for many different platforms:
+Like its predecessor Turbo Pascal, at the core of Delphi is a native code compiler.
+Turbo Pascal provided an ideal balance between the speed of programming and the speed of the resulting programs, clarity of syntax and power of expression, these tenets remain true today in Delphi.
+More recent versions of Delphi are able to compile native code for many different platforms:
 
 - **Windows (x86 and x64)**  
 - **OS X (32 bit only)**  
@@ -20,4 +22,5 @@ of expression, these tenets remain true today in Delphi.  More recent versions o
 - **Android**  
 - **Linux (64 bit only)**  
 
-In 2006, Borland’s developer tools section were transferred from Borland to a wholly owned subsidiary known as [CodeGear](https://en.wikipedia.org/wiki/CodeGear), which was sold to [Embarcadero Technologies](https://en.wikipedia.org/wiki/Embarcadero_Technologies) in 2008. In 2015, Embarcadero was purchased by Idera, but the Embarcadero mark was retained for the developer tools division.
+In 2006, Borland’s developer tools section were transferred from Borland to a wholly owned subsidiary known as [CodeGear](https://en.wikipedia.org/wiki/CodeGear), which was sold to [Embarcadero Technologies](https://en.wikipedia.org/wiki/Embarcadero_Technologies) in 2008.
+In 2015, Embarcadero was purchased by Idera, but the Embarcadero mark was retained for the developer tools division.


### PR DESCRIPTION
About.md now follows formatting guidelines described in #234.