### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -75,7 +75,8 @@
       "difficulty": 1,
       "topics": [
         "control_flow_loops",
-        "integers"
+        "integers",
+        "math"
       ]
     },
     {
@@ -198,6 +199,7 @@
       "topics": [
         "algorithms",
         "looping",
+        "math",
         "raising_exceptions"
       ]
     },
@@ -208,7 +210,8 @@
       "unlocked_by": "collatz-conjecture",
       "difficulty": 2,
       "topics": [
-        "algorithms"
+        "algorithms",
+        "math"
       ]
     },
     {
@@ -273,7 +276,8 @@
       "unlocked_by": "leap",
       "difficulty": 3,
       "topics": [
-        "integers"
+        "integers",
+        "math"
       ]
     },
     {
@@ -340,9 +344,9 @@
       "unlocked_by": "bob",
       "difficulty": 4,
       "topics": [
-      "dictionaries",
-      "strings",
-      "transforming"
+        "dictionaries",
+        "strings",
+        "transforming"
       ]
     },
     {


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110