### PR TITLE
reassignment of exercises in configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -603,7 +603,7 @@
       "slug": "bowling",
       "uuid": "88f7ab7d-30c1-4cb5-81ff-1114b5f78291",
       "core": false,
-      "unlocked_by": "circular-buffer",
+      "unlocked_by": "markdown",
       "difficulty": 6,
       "topics": [
         "algorithms",

--- a/config.json
+++ b/config.json
@@ -546,8 +546,8 @@
     {
       "slug": "circular-buffer",
       "uuid": "f949b958-d2e0-4f21-a6db-12ba89f8ab57",
-      "core": true,
-      "unlocked_by": null,
+      "core": false,
+      "unlocked_by": "markdown",
       "difficulty": 5,
       "topics": [
         "classes",


### PR DESCRIPTION
Demoted `circular-buffer` to a side exercise.
`Bowling` now unlocked by `markdown` instead of unlocked by `circular-buffer`.