### PR TITLE
high-scores: revamped implementation to closely match topic

### DIFF
--- a/config.json
+++ b/config.json
@@ -73,8 +73,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "lists",
-        "strings"
+        "lists"
       ]
     },
     {

--- a/exercises/high-scores/.meta/hints.md
+++ b/exercises/high-scores/.meta/hints.md
@@ -1,0 +1,2 @@
+## Hints
+- Lists is the topic being introduced in this exercise.  `TList<T>` can be utilized when you use System.Generics.Collections.

--- a/exercises/high-scores/uHighScoresExample.pas
+++ b/exercises/high-scores/uHighScoresExample.pas
@@ -1,64 +1,71 @@
 unit uHighScores;
 
 interface
+uses
+  System.Generics.Collections;
 
 type
   IScores = interface(IInvokable)
   ['{3D174C80-BA8D-4D92-AB1B-DA29ED0812CE}']
-    function Input(AInput: TArray<integer>): ISCores;
-    function Scores:  TArray<integer>;
+    function Scores: TList<integer>;
     function Latest: integer;
     function Highest: integer;
-    function personalTopThree: TArray<integer>;
+    function personalTopThree: TList<integer>;
     function Report: string;
   end;
 
-function NewScores: IScores;
+function NewScores(aInputScores: TArray<integer>): IScores;
 
 implementation
 
 uses
-  System.Generics.Collections, System.SysUtils;
+  System.SysUtils;
 
 type
-
   TScores = class(TInterfacedObject, IScores)
   private
-    FScores: TArray<integer>;
+    FScores: TList<integer>;
   public
-    function Input(AInput: TArray<integer>): ISCores;
-    function Scores:  TArray<integer>;
+    constructor Create(const aInputScores: TArray<integer>);
+    destructor Destroy; override;
+    function Scores:  TList<integer>;
     function Latest: integer;
     function Highest: integer;
-    function personalTopThree: TArray<integer>;
+    function personalTopThree: TList<integer>;
     function Report: string;
   end;
 
  { TScores }
 
-function NewScores: IScores;
+function NewScores(aInputScores: TArray<integer>): IScores;
 begin
-  result := TScores.Create;
+  result := TScores.Create(aInputScores);
+end;
+
+constructor TScores.Create(const aInputScores: TArray<integer>);
+begin
+  FScores := TList<integer>.Create;
+  FScores.AddRange(aInputScores);
+end;
+
+destructor TScores.Destroy;
+begin
+  FScores.DisposeOf;
+  inherited;
 end;
 
 function TScores.Highest: integer;
 begin
-  var l := TList<integer>.Create;
-  l.AddRange(FScores);
-  l.Sort;
-  Result := l.Last;
-  l.DisposeOf;
-end;
-
-function TScores.Input(AInput: TArray<integer>): ISCores;
-begin
-  FScores := AInput;
-  Result := self;
+  var lScoresList := TList<integer>.Create;
+  lScoresList.AddRange(FScores);
+  lScoresList.Sort;
+  Result := lScoresList.Last;
+  lScoresList.DisposeOf;
 end;
 
 function TScores.Latest: integer;
 begin
-  Result := FScores[High(FScores)];
+  Result := FScores.Last;
 end;
 
 function TScores.Report: string;
@@ -71,21 +78,20 @@ begin
     Result := format('Your latest score was %d. That''s %d short of your personal best!',[L, H - L]);
 end;
 
-function TScores.Scores: TArray<integer>;
+function TScores.Scores: TList<integer>;
 begin
   Result := FScores;
 end;
 
-function TScores.personalTopThree: TArray<integer>;
+function TScores.personalTopThree: TList<integer>;
 begin
-  var l := TList<integer>.Create;
-  l.AddRange(FScores);
-  l.Sort;
-  l.Reverse;
-  if l.Count > 3 then
-    l.Count := 3;
-  Result := l.ToArray;
-  l.DisposeOf;
+  var lTopThree := TList<integer>.Create;
+  lTopThree.AddRange(FScores);
+  lTopThree.Sort;
+  lTopThree.Reverse;
+  if lTopThree.Count > 3 then
+    lTopThree.Count := 3;
+  Result := lTopThree;
 end;
 
 end.


### PR DESCRIPTION
The exercise was not really utilizing lists.  That has been corrected.