### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 **Delphi** is an Object Pascal based programming language for desktop, mobile, web, and console software development.
 Delphi was the [code name](https://edn.embarcadero.com/article/20396) for a yet unnamed product during its initial development prior to its debut in 1995.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,13 +1,13 @@
 # Installing Delphi and DUnitX Testing Framework #
-### Windows ###
+## Windows ###
 
 A free [Community Edition](https://www.embarcadero.com/products/delphi/starter) version is available.  Follow installation instructions included with the product.
 
-### Non-Windows based Operating Systems ###
+## Non-Windows based Operating Systems ###
 
 Delphi will only run in a Windows based operating system.  Delphi may be run within a virtual machine that is hosting Windows.
 
-### Installing DUnitX Test Framework ###
+## Installing DUnitX Test Framework ###
 DUnitX may be optionally installed while installing Delphi versions XE8 and up.  However, I recommend following the instructions below and manually, obtaining a copy of DUnitX directly from the authors GitHub repository as it is updated more frequently.
 
 With Delphi successfully installed, please follow these steps for retrieving and installing DUnitX if you find that your installation of Delphi is lacking this testing framework.
@@ -16,7 +16,7 @@ With Delphi successfully installed, please follow these steps for retrieving and
 - It is best to fork the repo and then clone or otherwise download the fork to your local machine.
 - Step-by-step instructions on how to install DUnitX into Delphi have been posted by Vincent Parrett in a blog post located [here](https://www.finalbuilder.com/resources/blogs/postid/702/dunitx-has-a-wizard).
 
-### Delphi Configuration for DUnitX ###
+## Delphi Configuration for DUnitX ###
 
 If you installed DUnitX manually because your installation didn't already come with it then please follow the following illustrated steps to make the necessary configuration changes to Delphi in order for it to locate your installation of DUnitX.
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for those learning Pascal for the first time. These resources can help you get started:
 
 * [Pascal Tutorial](https://www.tutorialspoint.com/pascal/index.htm) looks like a good place to get your feet we with Pascal if you have zero experience with this language.  You do not need Delphi to complete the exercises covered in this tutorial.  This may be a good place to practice up before jumping in to the exercises here, which do require Delphi to complete.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,4 +1,4 @@
-## Recommended Learning Resources
+# Recommended Learning Resources
 
 The [Delphi Basics](http://www.delphibasics.co.uk/) is a good reference on Delphi.
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## Running The Tests 
+# Running The Tests 
 
 Exercises that have been fetched using the [Exercism command line client](https://exercism.io/cli) are delivered with a minimum of three files: a `readme.md` file, a `.dpr` file, and a `.pas` file.  The `.dpr` file is the Delphi project file and the `.pas` file is the test runner.  Load the Delphi project by either double clicking on the `.dpr` file or by opening the project from within Delphi.  You will be responsible for creating a new `.pas` file that will contain your solution code that the tests will be run against.  Refer to the `readme.md` file for instruction on how to compile and execute your code.
 

--- a/exercises/practice/hello-world/GETTING_STARTED_GUIDE.md
+++ b/exercises/practice/hello-world/GETTING_STARTED_GUIDE.md
@@ -1,3 +1,5 @@
+# getting started guide
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Lists is the topic being introduced in this exercise.  `TList<T>` can be utilized when you use System.Generics.Collections.

--- a/exercises/practice/rational-numbers/.docs/instructions.append.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.append.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Operator overloading is being introduced in this exercise.  The [Embarcadero docwiki](http://docwiki.embarcadero.com/RADStudio/Rio/en/Operator_Overloading_(Delphi)) on the subject will be very helpful to you in understanding how overriding class operators is possible along with Implicit and Explicit casting.

--- a/exercises/practice/twelve-days/.docs/instructions.append.md
+++ b/exercises/practice/twelve-days/.docs/instructions.append.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
