### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/uHelloWorld.pas
+++ b/exercises/practice/hello-world/uHelloWorld.pas
@@ -8,7 +8,7 @@ implementation
 
 function Hello: string;
 begin
-  result := 'Hello, World!';
+  result := 'Goodbye, Mars!';
 end;
 
 end.


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46