### PR TITLE
Remove reference to Gitter

### DIFF
--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,3 +1,0 @@
-# Help
-
-We monitor the [Pascal-Delphi](https://gitter.im/exercism/Pascal-Delphi) support room on [gitter.im](https://gitter.im) to help you with any questions that might arise.


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
