### PR TITLE
two-fer: Add Training Tags.

### DIFF
--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -17,5 +17,21 @@
     ]
   },
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "source_url": "https://github.com/exercism/problem-specifications/issues/757"
+  "source_url": "https://github.com/exercism/problem-specifications/issues/757",
+  "tag_filters": {
+    "construct": ["add"],
+    "construct": ["assignment"],
+    "construct": ["class"],
+    "construct": ["constructor"],
+    "construct": ["method"],
+    "construct": ["parameter"],
+    "construct": ["string"],
+    "construct": ["throw"],
+    "construct": ["try"],
+    "construct": ["unit"],
+    "construct": ["uses"],
+    "construct": ["visibility-modifiers"],
+    "paradigm": ["object-oriented"],
+    "technique": ["exceptions"]
+  }
 }


### PR DESCRIPTION
This PR is in response to #507.  @ihid or @ErikSchierboom I have only attempted to update config.json on a single exercise in order to confirm that I am on the right track.  I do not believe I have access to the insider videos, none of them are clickable for me.  So I have followed what I read [here](https://forum.exercism.org/t/proposal-adding-tag-detection-to-analyzers/6931#community-solutions-7) and using the information provided for two-fer.