### PR TITLE
resistor-color: sync

### DIFF
--- a/exercises/practice/resistor-color/.docs/instructions.md
+++ b/exercises/practice/resistor-color/.docs/instructions.md
@@ -3,8 +3,8 @@
 If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
 For this exercise, you need to know two things about them:
 
-* Each resistor has a resistance value.
-* Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
 
 To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
 Each band has a position and a numeric value.
@@ -15,21 +15,25 @@ In this exercise you are going to create a helpful program so that you don't hav
 
 These colors are encoded as follows:
 
-- Black: 0
-- Brown: 1
-- Red: 2
-- Orange: 3
-- Yellow: 4
-- Green: 5
-- Blue: 6
-- Violet: 7
-- Grey: 8
-- White: 9
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
 
 The goal of this exercise is to create a way:
+
 - to look up the numerical value associated with a particular color band
 - to list the different band colors
 
-Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array:
+Better Be Right Or Your Great Big Values Go Wrong.
 
-More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article][e-color-code].
+
+[e-color-code]: https://en.wikipedia.org/wiki/Electronic_color_code

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -13,7 +13,7 @@
       ".meta/uResistorColorExample.pas"
     ]
   },
-  "blurb": "Convert a resistor band's color to its numeric representation",
+  "blurb": "Convert a resistor band's color to its numeric representation.",
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"
 }


### PR DESCRIPTION
Sync the `resistor-color` exercise with the latest data, as defined in https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color.

- Feel free to close this PR if there is another PR that also syncs this exercise.
- When approved, feel free to merge this PR yourselves (you don't have to wait for me).

As this PR only updates docs and/or metadata, it won't trigger a re-run of existing solutions (see [the docs](https://exercism.org/docs/building/tracks)).