### PR TITLE
Sync `triangle` and add stub

### DIFF
--- a/exercises/practice/triangle/.docs/instructions.md
+++ b/exercises/practice/triangle/.docs/instructions.md
@@ -4,20 +4,26 @@ Determine if a triangle is equilateral, isosceles, or scalene.
 
 An _equilateral_ triangle has all three sides the same length.
 
-An _isosceles_ triangle has at least two sides the same length. (It is sometimes
-specified as having exactly two sides the same length, but for the purposes of
-this exercise we'll say at least two.)
+An _isosceles_ triangle has at least two sides the same length.
+(It is sometimes specified as having exactly two sides the same length, but for the purposes of this exercise we'll say at least two.)
 
 A _scalene_ triangle has all sides of different lengths.
 
 ## Note
 
-For a shape to be a triangle at all, all sides have to be of length > 0, and
-the sum of the lengths of any two sides must be greater than or equal to the
-length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+For a shape to be a triangle at all, all sides have to be of length > 0, and the sum of the lengths of any two sides must be greater than or equal to the length of the third side.
 
-## Dig Deeper
+In equations:
 
-The case where the sum of the lengths of two sides _equals_ that of the
-third is known as a _degenerate_ triangle - it has zero area and looks like
-a single line. Feel free to add your own code/tests to check for degenerate triangles.
+Let `a`, `b`, and `c` be sides of the triangle.
+Then all three of the following expressions must be true:
+
+```text
+a + b ≥ c
+b + c ≥ a
+a + c ≥ b
+```
+
+See [Triangle Inequality][triangle-inequality]
+
+[triangle-inequality]: https://en.wikipedia.org/wiki/Triangle_inequality

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -15,5 +15,5 @@
   },
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "source": "The Ruby Koans triangle project, parts 1 & 2",
-  "source_url": "http://rubykoans.com"
+  "source_url": "https://web.archive.org/web/20220831105330/http://rubykoans.com"
 }

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,60 +1,73 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [8b2c43ac-7257-43f9-b552-7631a91988af]
-description = "all sides are equal"
+description = "equilateral triangle -> all sides are equal"
 
 [33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
-description = "any side is unequal"
+description = "equilateral triangle -> any side is unequal"
 
 [c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
-description = "no sides are equal"
+description = "equilateral triangle -> no sides are equal"
 
 [16e8ceb0-eadb-46d1-b892-c50327479251]
-description = "all zero sides is not a triangle"
+description = "equilateral triangle -> all zero sides is not a triangle"
 
 [3022f537-b8e5-4cc1-8f12-fd775827a00c]
-description = "sides may be floats"
+description = "equilateral triangle -> sides may be floats"
 
 [cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
-description = "last two sides are equal"
+description = "isosceles triangle -> last two sides are equal"
 
 [e388ce93-f25e-4daf-b977-4b7ede992217]
-description = "first two sides are equal"
+description = "isosceles triangle -> first two sides are equal"
 
 [d2080b79-4523-4c3f-9d42-2da6e81ab30f]
-description = "first and last sides are equal"
+description = "isosceles triangle -> first and last sides are equal"
 
 [8d71e185-2bd7-4841-b7e1-71689a5491d8]
-description = "equilateral triangles are also isosceles"
+description = "isosceles triangle -> equilateral triangles are also isosceles"
 
 [840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
-description = "no sides are equal"
+description = "isosceles triangle -> no sides are equal"
 
 [2eba0cfb-6c65-4c40-8146-30b608905eae]
-description = "first triangle inequality violation"
+description = "isosceles triangle -> first triangle inequality violation"
 
 [278469cb-ac6b-41f0-81d4-66d9b828f8ac]
-description = "second triangle inequality violation"
+description = "isosceles triangle -> second triangle inequality violation"
 
 [90efb0c7-72bb-4514-b320-3a3892e278ff]
-description = "third triangle inequality violation"
+description = "isosceles triangle -> third triangle inequality violation"
 
 [adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
-description = "sides may be floats"
+description = "isosceles triangle -> sides may be floats"
 
 [e8b5f09c-ec2e-47c1-abec-f35095733afb]
-description = "no sides are equal"
+description = "scalene triangle -> no sides are equal"
 
 [2510001f-b44d-4d18-9872-2303e7977dc1]
-description = "all sides are equal"
+description = "scalene triangle -> all sides are equal"
 
 [c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
-description = "two sides are equal"
+description = "scalene triangle -> first and second sides are equal"
+
+[3da23a91-a166-419a-9abf-baf4868fd985]
+description = "scalene triangle -> first and third sides are equal"
+
+[b6a75d98-1fef-4c42-8e9a-9db854ba0a4d]
+description = "scalene triangle -> second and third sides are equal"
 
 [70ad5154-0033-48b7-af2c-b8d739cd9fdc]
-description = "may not violate triangle inequality"
+description = "scalene triangle -> may not violate triangle inequality"
 
 [26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
-description = "sides may be floats"
+description = "scalene triangle -> sides may be floats"

--- a/exercises/practice/triangle/uTriangle.pas
+++ b/exercises/practice/triangle/uTriangle.pas
@@ -1,0 +1,15 @@
+unit uTriangle;
+
+interface
+
+type
+  TriangleKind = (Equilateral, Isosceles, Scalene);
+
+  Triangle = class
+  public
+    class function Sides(aIsKind: TriangleKind; aSide1, aSide2, aSide3: double): boolean; static;
+  end;
+
+implementation
+     // Provide your implementation here
+end.

--- a/exercises/practice/triangle/uTriangleTests.pas
+++ b/exercises/practice/triangle/uTriangleTests.pas
@@ -84,8 +84,16 @@ type
 
     [Test]
     [Ignore]
-    procedure TwoSidesAreEqual;
+    procedure FirstAndSecondSidesAreEqual;
 
+    [Test]
+    [Ignore]
+    procedure FirstAndThirdSidesAreEqual;
+
+    [Test]
+    [Ignore]
+    procedure SecondAndThirdSidesAreEqual;
+  
     [Test]
     [Ignore]
     procedure MayNotViolateTriangleInequality;
@@ -183,10 +191,20 @@ begin
   Assert.AreEqual(false, Triangle.Sides(Scalene, 4, 4, 4)); 
 end; 
  
-procedure ScaleneTests.TwoSidesAreEqual;
+procedure ScaleneTests.FirstAndSecondSidesAreEqual;
 begin 
   Assert.AreEqual(false, Triangle.Sides(Scalene, 4, 4, 3)); 
 end; 
+ 
+procedure ScaleneTests.FirstAndThirdSidesAreEqual;
+begin 
+  Assert.AreEqual(false, Triangle.Sides(Scalene, 3, 4, 3)); 
+end;
+ 
+procedure ScaleneTests.SecondAndThirdSidesAreEqual;
+begin 
+  Assert.AreEqual(false, Triangle.Sides(Scalene, 4, 3, 3)); 
+end;
  
 procedure ScaleneTests.MayNotViolateTriangleInequality;
 begin 


### PR DESCRIPTION
This syncs the docs, metadata, and tests for `triangle`. This adds two tests for scalene triangles that check other combinations of the two sides being equal. I also added an non-compiling stub that gives the student the minimum interface needed to pass the tests.

After this, there are 37 exercises where `configlet` is reporting one or more tests missing since the test.toml files were last updated.