### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions Append
 
-## Implementation
+## Track specific instructions
 
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 - Lists is the topic being introduced in this exercise.  `TList<T>` can be utilized when you use System.Generics.Collections.

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,2 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
+
 - Lists is the topic being introduced in this exercise.  `TList<T>` can be utilized when you use System.Generics.Collections.

--- a/exercises/practice/rational-numbers/.docs/instructions.append.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.append.md
@@ -1,2 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
+
 - Operator overloading is being introduced in this exercise.  The [Embarcadero docwiki](http://docwiki.embarcadero.com/RADStudio/Rio/en/Operator_Overloading_(Delphi)) on the subject will be very helpful to you in understanding how overriding class operators is possible along with Implicit and Explicit casting.

--- a/exercises/practice/rational-numbers/.docs/instructions.append.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 - Operator overloading is being introduced in this exercise.  The [Embarcadero docwiki](http://docwiki.embarcadero.com/RADStudio/Rio/en/Operator_Overloading_(Delphi)) on the subject will be very helpful to you in understanding how overriding class operators is possible along with Implicit and Explicit casting.

--- a/exercises/practice/twelve-days/.docs/instructions.append.md
+++ b/exercises/practice/twelve-days/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/twelve-days/.docs/instructions.append.md
+++ b/exercises/practice/twelve-days/.docs/instructions.append.md
@@ -1,2 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
+
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.